### PR TITLE
Add minimal CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
 
 jobs:
     build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [push]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Set up JDK 11
+              uses: actions/setup-java@v1
+              with:
+                  java-version: 11
+            - name: Build with Maven
+              run: mvn -B package --file pom.xml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 HELMHOLTZ MARKETPLACE CEREBRUM
 ===================
 
-![](https://github.com/helmoltz-markeplace/helmoltz-cerebrum/workflows/CI/badge.svg)
+![CI](https://github.com/helmholtz-marketplace/helmholtz-cerebrum/workflows/CI/badge.svg)
+
+![CI](workflows/CI/badge.svg)

--- a/README.md
+++ b/README.md
@@ -2,5 +2,3 @@ HELMHOLTZ MARKETPLACE CEREBRUM
 ===================
 
 ![CI](https://github.com/helmholtz-marketplace/helmholtz-cerebrum/workflows/CI/badge.svg)
-
-![CI](workflows/CI/badge.svg)


### PR DESCRIPTION
Motivation:
* add minimal CI so that we have a build on push and PRs

Modification:
* add minimal workflow configuration so that we have a Maven build after push or PRs

Result:
* a Maven build is being executed after push or PRs and the CI badge is being shown in the README.md

